### PR TITLE
Remove variables from select statement

### DIFF
--- a/08-select-grouped-and-aggregated-data-with-sql/lesson.md
+++ b/08-select-grouped-and-aggregated-data-with-sql/lesson.md
@@ -7,7 +7,7 @@ select min(create_date) from Users;
 
 ### Find the highest value create_date in Table
 ```
-select max(create_date), last_name, first_name from Users;
+select max(create_date) from Users;
 ```
 
 ### Count all users with the same last name


### PR DESCRIPTION
## Changes made
You can't have `SELECT` statements have aggregate functions returned in tandem with other columns unless there is a `GROUP BY` statement including those columns

- Removed `last_name` and `first_name` from `SELECT` statement

![](https://media0.giphy.com/media/14smAwp2uHM3Di/200w.gif?cid=5a38a5a25ccc275054335535518102ce&rid=200w.gif)
